### PR TITLE
fix: add None check out of scoped variable

### DIFF
--- a/src/ai/backend/client/request.py
+++ b/src/ai/backend/client/request.py
@@ -5,7 +5,6 @@ import functools
 import io
 import json as modjson
 import logging
-import sys
 from collections import OrderedDict, namedtuple
 from datetime import datetime
 from decimal import Decimal
@@ -597,7 +596,6 @@ class FetchContextManager:
                     continue
             except aiohttp.ClientResponseError as e:
                 msg = "API endpoint response error.\n\u279c {!r}".format(e)
-                await raw_resp.__aexit__(*sys.exc_info())
                 raise BackendClientError(msg) from e
             finally:
                 self.session.config.load_balance_endpoints()


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

- resolves https://github.com/lablup/backend.ai-ossca-2023/issues/3
- ~~just remove out of scope variable.~~ add check block for `variable is not None`.
- So, that makes correct error response when got ClientResponseError in FetchContextManager.

before

```
✗ [0] cannot access local variable 'raw_resp' where it is not associated with a value
```

after

```
✗ [0] BackendClientError("API endpoint response error.\n➜ ClientResponseError(RequestInfo(url=URL('http://127.0.0.1:6011/session'), method='POST', headers=<CIMultiDictProxy('Host': '127.0.0.1:6011', 'User-Agent': 'Backend.AI Client for Python 23.03.9.dev0', 'X-BackendAI-Domain': 'default', 'X-BackendAI-Version': 'v7.20230615', 'Date': '2023-07-20T08:29:03.767375+00:00', 'Content-Type': 'application/json', 'Authorization': 'BackendAI signMethod=HMAC-SHA256, credential=AKIAIOSFODNN7EXAMPLE:8a8c57ef22208c21eb27c1fe7b68e5e5773de6e21849fd78f2579654c6bf6f4c', 'Accept': '*/*', 'Accept-Encoding': 'gzip, deflate', 'Content-Length': '543')>, real_url=URL('http://127.0.0.1:6011/session')), (), status=400, message='Expected HTTP/')")
```

~~if `__aexit__` method must execute in except block, maybe edit that to use in self variable instead of local variable in try block.~~