### PR TITLE
fix : Set environment variables in session_data when enqueueing session

### DIFF
--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1284,6 +1284,7 @@ class AgentRegistry:
 
             async def _enqueue() -> None:
                 async with self.db.begin_session() as db_sess:
+                    session_data["environ"] = environ
                     session_data["requested_slots"] = session_requested_slots
                     session = SessionRow(**session_data)
                     kernels = [KernelRow(**kernel) for kernel in kernel_data]


### PR DESCRIPTION
Resolve #9 

Description:
It appears that there is an issue where the environment variables entered during the creation of a computing session through the WebUI are not reflected in the container.
So, this PR corrects the _enqueue() function within enqueue_session(). The function has been updated to assign the environ to session_data["environ"].

**Before:**

```python
async def _enqueue() -> None:
                async with self.db.begin_session() as db_sess:
                    session_data["requested_slots"] = session_requested_slots
                    session = SessionRow(**session_data)
                    kernels = [KernelRow(**kernel) for kernel in kernel_data]
                    db_sess.add(session)
                    db_sess.add_all(kernels)

            await execute_with_retry(_enqueue)
```
After:

```python
async def _enqueue() -> None:
                async with self.db.begin_session() as db_sess:
                    session_data["environ"] = environ
                    session_data["requested_slots"] = session_requested_slots
                    session = SessionRow(**session_data)
                    kernels = [KernelRow(**kernel) for kernel in kernel_data]
                    db_sess.add(session)
                    db_sess.add_all(kernels)

            await execute_with_retry(_enqueue)
```