### PR TITLE
fix: check min page size before fetch

### DIFF
--- a/src/ai/backend/client/pagination.py
+++ b/src/ai/backend/client/pagination.py
@@ -8,6 +8,7 @@ from .output.types import FieldSpec, PaginatedResult
 from .session import api_session
 
 MAX_PAGE_SIZE: Final = 100
+MIN_PAGE_SIZE: Final = 1
 
 T = TypeVar("T")
 
@@ -22,6 +23,8 @@ async def execute_paginated_query(
 ) -> PaginatedResult:
     if limit > MAX_PAGE_SIZE:
         raise ValueError(f"The page size cannot exceed {MAX_PAGE_SIZE}")
+    if limit < MIN_PAGE_SIZE:
+        raise ValueError(f"The page size cannot be less than {MIN_PAGE_SIZE}")
     query = """
     query($limit:Int!, $offset:Int!, $var_decls) {
       $root_field(
@@ -62,6 +65,8 @@ async def fetch_paginated_result(
 ) -> PaginatedResult:
     if page_size > MAX_PAGE_SIZE:
         raise ValueError(f"The page size cannot exceed {MAX_PAGE_SIZE}")
+    if page_size < MIN_PAGE_SIZE:
+        raise ValueError(f"The page size cannot be less than {MIN_PAGE_SIZE}")
     if api_session.get().api_version < (6, "20210815"):
         if variables["filter"][0] is not None or variables["order"][0] is not None:
             raise BackendAPIVersionError(


### PR DESCRIPTION
<!--
Please precisely, concisely, and concretely describe what this PR changes, the rationale behind codes,
and how it affects the users and other developers.
-->

- resolves https://github.com/lablup/backend.ai-ossca-2023/issues/15
- currently, `fetch_paginated_result` is not check minimum page_size aka limit.
- so it occur infinity fetch error, this PR is add check page_size(limit) variable block.
- also double check in `execute_paginated_query` function for safety.